### PR TITLE
Feature: getViewOrThrow() in onAttachView() Lint-Check

### DIFF
--- a/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/TiIssue.kt
+++ b/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/TiIssue.kt
@@ -27,7 +27,7 @@ sealed class TiIssue(
 
     object GetViewOrThrowInOnAttach : TiIssue(
             id = "GetViewOrThrowInOnAttach",
-            briefDescription = "getView() might be null when used in TiPresenter.onAttach(). So getViewOrThrow() might throw an exception.",
+            briefDescription = "TiPresenter.getViewOrThrow() might throw an exception",
             category = CATEGORY_TI,
             priority = 6,
             severity = Severity.WARNING

--- a/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/TiIssue.kt
+++ b/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/TiIssue.kt
@@ -25,6 +25,14 @@ sealed class TiIssue(
             severity = Severity.ERROR
     )
 
+    object GetViewOrThrowInOnAttach : TiIssue(
+            id = "GetViewOrThrowInOnAttach",
+            briefDescription = "getView() might be null when used in TiPresenter.onAttach(). So getViewOrThrow() might throw an exception.",
+            category = CATEGORY_TI,
+            priority = 6,
+            severity = Severity.WARNING
+    )
+
     fun asLintIssue(detectorCls: Class<out Detector>, description: String = briefDescription): Issue =
             Issue.create(
                     id,

--- a/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/TiLintRegistry.kt
+++ b/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/TiLintRegistry.kt
@@ -2,17 +2,20 @@ package net.grandcentrix.thirtyinch.lint
 
 import com.android.tools.lint.client.api.IssueRegistry
 import com.android.tools.lint.detector.api.Issue
+import net.grandcentrix.thirtyinch.lint.detector.GetViewOrThrowInOnAttachDetector
 import net.grandcentrix.thirtyinch.lint.detector.MissingViewInCompositeDetector
 import net.grandcentrix.thirtyinch.lint.detector.MissingViewInThirtyInchDetector
 
 class TiLintRegistry : IssueRegistry() {
-    override val issues: List<Issue>
-        get() = listOf(
-                MissingViewInThirtyInchDetector.ISSUE.apply {
-                    setEnabledByDefault(true)
-                },
-                MissingViewInCompositeDetector.ISSUE.apply {
-                    setEnabledByDefault(true)
-                }
-        )
+    override val issues: List<Issue> = listOf(
+            MissingViewInThirtyInchDetector.ISSUE.apply {
+                setEnabledByDefault(true)
+            },
+            MissingViewInCompositeDetector.ISSUE.apply {
+                setEnabledByDefault(true)
+            },
+            GetViewOrThrowInOnAttachDetector.ISSUE.apply {
+                setEnabledByDefault(true)
+            }
+    )
 }

--- a/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/detector/GetViewOrThrowInOnAttachDetector.kt
+++ b/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/detector/GetViewOrThrowInOnAttachDetector.kt
@@ -14,14 +14,11 @@ import org.jetbrains.uast.UReturnExpression
 import org.jetbrains.uast.getUastContext
 import org.jetbrains.uast.toUElement
 
+private const val TI_CLASS_PRESENTER = "net.grandcentrix.thirtyinch.TiPresenter"
 private const val TI_METHOD_ONATTACHVIEW = "onAttachView"
 private const val TI_METHOD_GETVIEWORTHROW = "getViewOrThrow"
 
 private const val MAX_TRANSITIVE_CHECK_DEPTH = 5
-
-private val TI_CLASS_NAMES = listOf(
-        "net.grandcentrix.thirtyinch.TiPresenter"
-)
 
 class GetViewOrThrowInOnAttachDetector : Detector(), Detector.UastScanner {
 
@@ -34,7 +31,7 @@ class GetViewOrThrowInOnAttachDetector : Detector(), Detector.UastScanner {
         )
     }
 
-    override fun applicableSuperClasses(): List<String> = TI_CLASS_NAMES
+    override fun applicableSuperClasses(): List<String> = listOf(TI_CLASS_PRESENTER)
 
     override fun visitClass(context: JavaContext, declaration: UClass) {
         val methods = declaration.findMethodsByName(TI_METHOD_ONATTACHVIEW, true)

--- a/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/detector/GetViewOrThrowInOnAttachDetector.kt
+++ b/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/detector/GetViewOrThrowInOnAttachDetector.kt
@@ -58,7 +58,7 @@ class GetViewOrThrowInOnAttachDetector : Detector(), Detector.UastScanner {
                 uElement.returnExpression?.run { checkForTransitiveUsage(context, uElement = this) }
             }
             is UCallExpression -> {
-                if (shouldWarn(uElement)) report(context, uElement)
+                if (shouldWarn(context, uElement)) report(context, uElement)
                 else {
                     uElement.resolve()
                             ?.let { uElement.getUastContext().getMethodBody(it) }
@@ -68,9 +68,10 @@ class GetViewOrThrowInOnAttachDetector : Detector(), Detector.UastScanner {
         }
     }
 
-    private fun shouldWarn(call: UCallExpression): Boolean {
-        return call.valueArgumentCount == 0 && TI_METHOD_GETVIEWORTHROW == call.methodName
-        // TODO do a check if the method is from the right class
+    private fun shouldWarn(context: JavaContext, call: UCallExpression): Boolean {
+        return call.valueArgumentCount == 0
+                && TI_METHOD_GETVIEWORTHROW == call.methodName
+                && call.resolve()?.let { context.evaluator.isMemberInClass(it, TI_CLASS_PRESENTER) } == true
     }
 
     private fun report(context: JavaContext, element: UCallExpression) {

--- a/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/detector/GetViewOrThrowInOnAttachDetector.kt
+++ b/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/detector/GetViewOrThrowInOnAttachDetector.kt
@@ -1,0 +1,86 @@
+package net.grandcentrix.thirtyinch.lint.detector
+
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.TextFormat
+import net.grandcentrix.thirtyinch.lint.TiIssue.GetViewOrThrowInOnAttach
+import org.jetbrains.uast.UBlockExpression
+import org.jetbrains.uast.UCallExpression
+import org.jetbrains.uast.UClass
+import org.jetbrains.uast.UDeclarationsExpression
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.ULocalVariable
+import org.jetbrains.uast.UReturnExpression
+import org.jetbrains.uast.getUastContext
+import org.jetbrains.uast.toUElement
+
+private const val TI_METHOD_ONATTACHVIEW = "onAttachView"
+private const val TI_METHOD_GETVIEWORTHROW = "getViewOrThrow"
+
+private const val MAX_TRANSITIVE_CHECK_DEPTH = 5
+
+private val TI_CLASS_NAMES = listOf(
+        "net.grandcentrix.thirtyinch.TiPresenter"
+)
+
+class GetViewOrThrowInOnAttachDetector : Detector(), Detector.UastScanner {
+
+    companion object {
+        val ISSUE = GetViewOrThrowInOnAttach.asLintIssue(
+                GetViewOrThrowInOnAttachDetector::class.java,
+                "When using getViewOrThrow() in TiPresenter.onAttachView() the view might still be null." +
+                        " So getViewOrThrow() might throw an exception during runtime." +
+                        " Consider using the view parameter of TiPresenter.onAttachView() directly."
+        )
+    }
+
+    override fun applicableSuperClasses(): List<String> = TI_CLASS_NAMES
+
+    override fun visitClass(context: JavaContext, declaration: UClass) {
+        val methods = declaration.findMethodsByName(TI_METHOD_ONATTACHVIEW, true)
+
+        methods
+                .mapNotNull { method -> method.toUElement()?.getUastContext()?.getMethodBody(method) }
+                .forEach { methodBody -> checkForTransitiveUsage(context, methodBody) }
+    }
+
+    private fun checkForTransitiveUsage(context: JavaContext, uElement: UElement, depth: Int = 0) {
+        if (depth > MAX_TRANSITIVE_CHECK_DEPTH) return // limit check of call cascades to reduce lint check speed
+
+        when (uElement) {
+            is UBlockExpression -> {
+                uElement.expressions.forEach { checkForTransitiveUsage(context, it) }
+            }
+            is UDeclarationsExpression -> {
+                uElement.declarations.forEach { checkForTransitiveUsage(context, it) }
+            }
+            is ULocalVariable -> {
+                uElement.uastInitializer?.run { checkForTransitiveUsage(context, uElement = this) }
+            }
+            is UReturnExpression -> {
+                uElement.returnExpression?.run { checkForTransitiveUsage(context, uElement = this) }
+            }
+            is UCallExpression -> {
+                if (shouldWarn(uElement)) report(context, uElement)
+                else {
+                    uElement.resolve()
+                            ?.let { uElement.getUastContext().getMethodBody(it) }
+                            ?.run { checkForTransitiveUsage(context, uElement = this, depth = depth + 1) }
+                }
+            }
+        }
+    }
+
+    private fun shouldWarn(call: UCallExpression): Boolean {
+        return call.valueArgumentCount == 0 && TI_METHOD_GETVIEWORTHROW == call.methodName
+        // TODO do a check if the method is from the right class
+    }
+
+    private fun report(context: JavaContext, element: UCallExpression) {
+        context.report(
+                ISSUE,
+                context.getLocation(element.methodIdentifier ?: element),
+                ISSUE.getBriefDescription(TextFormat.TEXT)
+        )
+    }
+}

--- a/thirtyinch-lint/src/test/kotlin/net/grandcentrix/thirtyinch/lint/GetViewOrThrowInOnAttachDetectorTest.kt
+++ b/thirtyinch-lint/src/test/kotlin/net/grandcentrix/thirtyinch/lint/GetViewOrThrowInOnAttachDetectorTest.kt
@@ -27,8 +27,8 @@ class GetViewOrThrowInOnAttachDetectorTest : LintDetectorTest() {
                         "import net.grandcentrix.thirtyinch.*;\n" +
                         "public class MyPresenter extends TiPresenter<MyView> {\n" +
                         "  protected void onAttachView(MyView view) {\n" +
-                        "    val test = 42;\n" +
-                        "    val test = test();\n" +
+                        "    final int test = 42;\n" +
+                        "    final int test2 = test();\n" +
                         "    test();\n" +
                         "  }\n" +
                         "  private int test() {" +

--- a/thirtyinch-lint/src/test/kotlin/net/grandcentrix/thirtyinch/lint/GetViewOrThrowInOnAttachDetectorTest.kt
+++ b/thirtyinch-lint/src/test/kotlin/net/grandcentrix/thirtyinch/lint/GetViewOrThrowInOnAttachDetectorTest.kt
@@ -1,0 +1,180 @@
+package net.grandcentrix.thirtyinch.lint
+
+import com.android.tools.lint.checks.infrastructure.LintDetectorTest
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Issue
+import net.grandcentrix.thirtyinch.lint.detector.GetViewOrThrowInOnAttachDetector
+import org.assertj.core.api.Assertions
+
+private val view = LintDetectorTest.java(
+        "package foo;\n" +
+                "import net.grandcentrix.thirtyinch.*;\n" +
+                "interface MyView extends TiView {\n" +
+                "}"
+)
+
+class GetViewOrThrowInOnAttachDetectorTest : LintDetectorTest() {
+
+    override fun getIssues(): MutableList<Issue> = mutableListOf(GetViewOrThrowInOnAttachDetector.ISSUE)
+
+    override fun getDetector(): Detector {
+        return GetViewOrThrowInOnAttachDetector()
+    }
+
+    fun test_noDirectUsage_noWarning() {
+        val presenter = java(
+                "package foo;\n" +
+                        "import net.grandcentrix.thirtyinch.*;\n" +
+                        "public class MyPresenter extends TiPresenter<MyView> {\n" +
+                        "  protected void onAttachView(MyView view) {\n" +
+                        "    val test = 42;\n" +
+                        "    val test = test();\n" +
+                        "    test();\n" +
+                        "  }\n" +
+                        "  private int test() {" +
+                        "    return 42;\n" +
+                        "  }\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(
+                lintProject(
+                        tiPresenterStub,
+                        tiViewStub,
+                        view,
+                        presenter
+                )
+        ).isEqualTo(NO_WARNINGS)
+    }
+
+    fun test_getViewOrThrow_asMethod_hasWarning() {
+        val presenter = java(
+                "package foo;\n" +
+                        "import net.grandcentrix.thirtyinch.*;\n" +
+                        "public class MyPresenter extends TiPresenter<MyView> {\n" +
+                        "  protected void onAttachView(MyView view) {" +
+                        "    getViewOrThrow();" +
+                        "  }" +
+                        "}"
+        )
+
+        Assertions.assertThat(
+                lintProject(
+                        tiPresenterStub,
+                        tiViewStub,
+                        view,
+                        presenter
+                )
+        ).containsOnlyOnce(TiIssue.GetViewOrThrowInOnAttach.id)
+    }
+
+    fun test_getViewOrThrow_asAssignment_hasWarning() {
+        val presenter = java(
+                "package foo;\n" +
+                        "import net.grandcentrix.thirtyinch.*;\n" +
+                        "public class MyPresenter extends TiPresenter<MyView> {\n" +
+                        "  protected void onAttachView(MyView view) {\n" +
+                        "    MyView view = getViewOrThrow();\n" +
+                        "  }\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(
+                lintProject(
+                        tiPresenterStub,
+                        tiViewStub,
+                        view,
+                        presenter
+                )
+        ).containsOnlyOnce(TiIssue.GetViewOrThrowInOnAttach.id)
+    }
+
+    fun test_getViewOrThrow_asReturn_hasWarning() {
+        val presenter = java(
+                "package foo;\n" +
+                        "import net.grandcentrix.thirtyinch.*;\n" +
+                        "public class MyPresenter extends TiPresenter<MyView> {\n" +
+                        "  protected void onAttachView(MyView view) {\n" +
+                        "    MyView view = test();\n" +
+                        "  }\n" +
+                        "  private MyView test() {" +
+                        "    return getViewOrThrow();\n" +
+                        "  }\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(
+                lintProject(
+                        tiPresenterStub,
+                        tiViewStub,
+                        view,
+                        presenter
+                )
+        ).containsOnlyOnce(TiIssue.GetViewOrThrowInOnAttach.id)
+    }
+
+    fun test_getViewOrThrow_transitiveUsage_hasWarning() {
+        val presenter = java(
+                "package foo;\n" +
+                        "import net.grandcentrix.thirtyinch.*;\n" +
+                        "public class MyPresenter extends TiPresenter<MyView> {\n" +
+                        "  protected void onAttachView(MyView view) {\n" +
+                        "    test();\n" +
+                        "  }\n" +
+                        "  private void test() {" +
+                        "    test2();\n" +
+                        "  }\n" +
+                        "  private void test2() {" +
+                        "    test3();\n" +
+                        "  }\n" +
+                        "  private void test3() {" +
+                        "    test4();\n" +
+                        "  }\n" +
+                        "  private void test4() {" +
+                        "    getViewOrThrow();\n" +
+                        "  }\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(
+                lintProject(
+                        tiPresenterStub,
+                        tiViewStub,
+                        view,
+                        presenter
+                )
+        ).containsOnlyOnce(TiIssue.GetViewOrThrowInOnAttach.id)
+    }
+
+    fun test_noTransitiveUsage_noWarning() {
+        val presenter = java(
+                "package foo;\n" +
+                        "import net.grandcentrix.thirtyinch.*;\n" +
+                        "public class MyPresenter extends TiPresenter<MyView> {\n" +
+                        "  protected void onAttachView(MyView view) {\n" +
+                        "    test();\n" +
+                        "  }\n" +
+                        "  private void test() {" +
+                        "    test2();\n" +
+                        "  }\n" +
+                        "  private void test2() {" +
+                        "    test3();\n" +
+                        "  }\n" +
+                        "  private void test3() {" +
+                        "    test4();\n" +
+                        "  }\n" +
+                        "  private void test4() {" +
+                        "  }\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(
+                lintProject(
+                        tiPresenterStub,
+                        tiViewStub,
+                        view,
+                        presenter
+                )
+        ).isEqualTo(NO_WARNINGS)
+    }
+}

--- a/thirtyinch-lint/src/test/kotlin/net/grandcentrix/thirtyinch/lint/GetViewOrThrowInOnAttachDetectorTest.kt
+++ b/thirtyinch-lint/src/test/kotlin/net/grandcentrix/thirtyinch/lint/GetViewOrThrowInOnAttachDetectorTest.kt
@@ -22,7 +22,7 @@ class GetViewOrThrowInOnAttachDetectorTest : LintDetectorTest() {
         return GetViewOrThrowInOnAttachDetector()
     }
 
-    fun test_noDirectUsage_noWarning() {
+    fun testJava_noDirectUsage_noWarning() {
         val presenter = java(
                 "package foo;\n" +
                         "import net.grandcentrix.thirtyinch.*;\n" +
@@ -48,7 +48,33 @@ class GetViewOrThrowInOnAttachDetectorTest : LintDetectorTest() {
         ).isEqualTo(NO_WARNINGS)
     }
 
-    fun test_getViewOrThrow_asMethod_hasWarning() {
+    fun testKotlin_noDirectUsage_noWarning() {
+        val presenter = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.*\n" +
+                        "class MyPresenter : TiPresenter<MyView>() {\n" +
+                        "  override fun onAttachView(view: MyView) {" +
+                        "    val test = 42\n" +
+                        "    val test2 = test()\n" +
+                        "    test()\n" +
+                        "  }" +
+                        "  private fun test(): Int {" +
+                        "    return 42\n" +
+                        "  }\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(
+                lintProject(
+                        tiPresenterStub,
+                        tiViewStub,
+                        view,
+                        presenter
+                )
+        ).isEqualTo(NO_WARNINGS)
+    }
+
+    fun testJava_asMethod_hasWarning() {
         val presenter = java(
                 "package foo;\n" +
                         "import net.grandcentrix.thirtyinch.*;\n" +
@@ -69,7 +95,112 @@ class GetViewOrThrowInOnAttachDetectorTest : LintDetectorTest() {
         ).containsOnlyOnce(TiIssue.GetViewOrThrowInOnAttach.id)
     }
 
-    fun test_getViewOrThrow_asAssignment_hasWarning() {
+    fun testKotlin_asReference_hasWarning() {
+        val presenter = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.*\n" +
+                        "class MyPresenter : TiPresenter<MyView>() {\n" +
+                        "  override fun onAttachView(view: MyView) {" +
+                        "    viewOrThrow" +
+                        "  }" +
+                        "}"
+        )
+
+        Assertions.assertThat(
+                lintProject(
+                        tiPresenterStub,
+                        tiViewStub,
+                        view,
+                        presenter
+                )
+        ).containsOnlyOnce(TiIssue.GetViewOrThrowInOnAttach.id)
+    }
+
+    fun testKotlin_asMethod_hasWarning() {
+        val presenter = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.*\n" +
+                        "class MyPresenter : TiPresenter<MyView>() {\n" +
+                        "  override fun onAttachView(view: MyView) {" +
+                        "    getViewOrThrow()" +
+                        "  }" +
+                        "}"
+        )
+
+        Assertions.assertThat(
+                lintProject(
+                        tiPresenterStub,
+                        tiViewStub,
+                        view,
+                        presenter
+                )
+        ).containsOnlyOnce(TiIssue.GetViewOrThrowInOnAttach.id)
+    }
+
+    fun testJava_asMethod_chained_hasWarning() {
+        val presenter = java(
+                "package foo;\n" +
+                        "import net.grandcentrix.thirtyinch.*;\n" +
+                        "public class MyPresenter extends TiPresenter<MyView> {\n" +
+                        "  protected void onAttachView(MyView view) {" +
+                        "    getViewOrThrow().invoke();" +
+                        "  }" +
+                        "}"
+        )
+
+        Assertions.assertThat(
+                lintProject(
+                        tiPresenterStub,
+                        tiViewStub,
+                        view,
+                        presenter
+                )
+        ).containsOnlyOnce(TiIssue.GetViewOrThrowInOnAttach.id)
+    }
+
+    fun testKotlin_asReference_chained_hasWarning() {
+        val presenter = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.*\n" +
+                        "class MyPresenter : TiPresenter<MyView>() {\n" +
+                        "  override fun onAttachView(view: MyView) {" +
+                        "    viewOrThrow.invoke()" +
+                        "  }" +
+                        "}"
+        )
+
+        Assertions.assertThat(
+                lintProject(
+                        tiPresenterStub,
+                        tiViewStub,
+                        view,
+                        presenter
+                )
+        ).containsOnlyOnce(TiIssue.GetViewOrThrowInOnAttach.id)
+    }
+
+    fun testKotlin_asMethod_chained_hasWarning() {
+        val presenter = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.*\n" +
+                        "class MyPresenter : TiPresenter<MyView>() {\n" +
+                        "  override fun onAttachView(view: MyView) {" +
+                        "    getViewOrThrow().invoke()" +
+                        "  }" +
+                        "}"
+        )
+
+        Assertions.assertThat(
+                lintProject(
+                        tiPresenterStub,
+                        tiViewStub,
+                        view,
+                        presenter
+                )
+        ).containsOnlyOnce(TiIssue.GetViewOrThrowInOnAttach.id)
+    }
+
+    fun testJava_asAssignment_hasWarning() {
         val presenter = java(
                 "package foo;\n" +
                         "import net.grandcentrix.thirtyinch.*;\n" +
@@ -90,7 +221,7 @@ class GetViewOrThrowInOnAttachDetectorTest : LintDetectorTest() {
         ).containsOnlyOnce(TiIssue.GetViewOrThrowInOnAttach.id)
     }
 
-    fun test_getViewOrThrow_asReturn_hasWarning() {
+    fun testJava_asReturn_hasWarning() {
         val presenter = java(
                 "package foo;\n" +
                         "import net.grandcentrix.thirtyinch.*;\n" +
@@ -114,7 +245,55 @@ class GetViewOrThrowInOnAttachDetectorTest : LintDetectorTest() {
         ).containsOnlyOnce(TiIssue.GetViewOrThrowInOnAttach.id)
     }
 
-    fun test_getViewOrThrow_transitiveUsage_hasWarning() {
+    fun testKotlin_asReturn_reference_hasWarning() {
+        val presenter = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.*\n" +
+                        "class MyPresenter : TiPresenter<MyView>() {\n" +
+                        "  override fun onAttachView(view: MyView) {" +
+                        "    val view = test()\n" +
+                        "  }" +
+                        "  private fun test(): MyView {" +
+                        "    return viewOrThrow\n" +
+                        "  }\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(
+                lintProject(
+                        tiPresenterStub,
+                        tiViewStub,
+                        view,
+                        presenter
+                )
+        ).containsOnlyOnce(TiIssue.GetViewOrThrowInOnAttach.id)
+    }
+
+    fun testKotlin_asReturn_method_hasWarning() {
+        val presenter = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.*\n" +
+                        "class MyPresenter : TiPresenter<MyView>() {\n" +
+                        "  override fun onAttachView(view: MyView) {" +
+                        "    val view = test()\n" +
+                        "  }" +
+                        "  private fun test(): MyView {" +
+                        "    return getViewOrThrow()\n" +
+                        "  }\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(
+                lintProject(
+                        tiPresenterStub,
+                        tiViewStub,
+                        view,
+                        presenter
+                )
+        ).containsOnlyOnce(TiIssue.GetViewOrThrowInOnAttach.id)
+    }
+
+    fun testJava_transitiveUsage_hasWarning() {
         val presenter = java(
                 "package foo;\n" +
                         "import net.grandcentrix.thirtyinch.*;\n" +
@@ -147,7 +326,73 @@ class GetViewOrThrowInOnAttachDetectorTest : LintDetectorTest() {
         ).containsOnlyOnce(TiIssue.GetViewOrThrowInOnAttach.id)
     }
 
-    fun test_noTransitiveUsage_noWarning() {
+    fun testKotlin_transitiveUsage_reference_hasWarning() {
+        val presenter = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.*\n" +
+                        "class MyPresenter : TiPresenter<MyView>() {\n" +
+                        "  override fun onAttachView(view: MyView) {" +
+                        "    test()\n" +
+                        "  }" +
+                        "  private fun test() {" +
+                        "    test2()\n" +
+                        "  }\n" +
+                        "  private fun test2() {" +
+                        "    test3()\n" +
+                        "  }\n" +
+                        "  private fun test3() {" +
+                        "    test4()\n" +
+                        "  }\n" +
+                        "  private fun test4() {" +
+                        "    viewOrThrow\n" +
+                        "  }\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(
+                lintProject(
+                        tiPresenterStub,
+                        tiViewStub,
+                        view,
+                        presenter
+                )
+        ).containsOnlyOnce(TiIssue.GetViewOrThrowInOnAttach.id)
+    }
+
+    fun testKotlin_transitiveUsage_method_hasWarning() {
+        val presenter = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.*\n" +
+                        "class MyPresenter : TiPresenter<MyView>() {\n" +
+                        "  override fun onAttachView(view: MyView) {" +
+                        "    test()\n" +
+                        "  }" +
+                        "  private fun test() {" +
+                        "    test2()\n" +
+                        "  }\n" +
+                        "  private fun test2() {" +
+                        "    test3()\n" +
+                        "  }\n" +
+                        "  private fun test3() {" +
+                        "    test4()\n" +
+                        "  }\n" +
+                        "  private fun test4() {" +
+                        "    getViewOrThrow()\n" +
+                        "  }\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(
+                lintProject(
+                        tiPresenterStub,
+                        tiViewStub,
+                        view,
+                        presenter
+                )
+        ).containsOnlyOnce(TiIssue.GetViewOrThrowInOnAttach.id)
+    }
+
+    fun testJava_noTransitiveUsage_noWarning() {
         val presenter = java(
                 "package foo;\n" +
                         "import net.grandcentrix.thirtyinch.*;\n" +
@@ -165,6 +410,38 @@ class GetViewOrThrowInOnAttachDetectorTest : LintDetectorTest() {
                         "    test4();\n" +
                         "  }\n" +
                         "  private void test4() {" +
+                        "  }\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(
+                lintProject(
+                        tiPresenterStub,
+                        tiViewStub,
+                        view,
+                        presenter
+                )
+        ).isEqualTo(NO_WARNINGS)
+    }
+
+    fun testKotlin_noTransitiveUsage_noWarning() {
+        val presenter = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.*\n" +
+                        "class MyPresenter : TiPresenter<MyView>() {\n" +
+                        "  override fun onAttachView(view: MyView) {" +
+                        "    test()\n" +
+                        "  }" +
+                        "  private fun test() {" +
+                        "    test2()\n" +
+                        "  }\n" +
+                        "  private fun test2() {" +
+                        "    test3()\n" +
+                        "  }\n" +
+                        "  private fun test3() {" +
+                        "    test4()\n" +
+                        "  }\n" +
+                        "  private fun test4() {" +
                         "  }\n" +
                         "}"
         )

--- a/thirtyinch-lint/src/test/kotlin/net/grandcentrix/thirtyinch/lint/GetViewOrThrowInOnAttachDetectorTest.kt
+++ b/thirtyinch-lint/src/test/kotlin/net/grandcentrix/thirtyinch/lint/GetViewOrThrowInOnAttachDetectorTest.kt
@@ -10,6 +10,7 @@ private val view = LintDetectorTest.java(
         "package foo;\n" +
                 "import net.grandcentrix.thirtyinch.*;\n" +
                 "interface MyView extends TiView {\n" +
+                "  void invoke();\n" +
                 "}"
 )
 

--- a/thirtyinch-lint/src/test/kotlin/net/grandcentrix/thirtyinch/lint/LintUtils.kt
+++ b/thirtyinch-lint/src/test/kotlin/net/grandcentrix/thirtyinch/lint/LintUtils.kt
@@ -1,0 +1,35 @@
+package net.grandcentrix.thirtyinch.lint
+
+import com.android.tools.lint.checks.infrastructure.LintDetectorTest
+
+internal const val NO_WARNINGS = "No warnings."
+
+internal val tiActivityStub = LintDetectorTest.java(
+        "package net.grandcentrix.thirtyinch;\n" +
+                "public abstract class TiActivity<P extends TiPresenter<V>, V extends TiView> {\n" +
+                "}"
+)
+
+internal val tiFragmentStub = LintDetectorTest.java(
+        "package net.grandcentrix.thirtyinch;\n" +
+                "public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView> {\n" +
+                "}"
+)
+
+internal val tiViewStub = LintDetectorTest.java(
+        "package net.grandcentrix.thirtyinch;\n" +
+                "public interface TiView {\n" +
+                "}"
+)
+
+internal val tiPresenterStub = LintDetectorTest.java(
+        "package net.grandcentrix.thirtyinch;\n" +
+                "public abstract class TiPresenter<V extends TiView> {\n" +
+                "  public V getView() {\n" +
+                "        return null;\n" +
+                "  }\n" +
+                "  public V getViewOrThrow() {\n" +
+                "        return null;\n" +
+                "  }\n" +
+                "}"
+)

--- a/thirtyinch-lint/src/test/kotlin/net/grandcentrix/thirtyinch/lint/MissingViewInCompositeDetectorTest.kt
+++ b/thirtyinch-lint/src/test/kotlin/net/grandcentrix/thirtyinch/lint/MissingViewInCompositeDetectorTest.kt
@@ -6,23 +6,9 @@ import com.android.tools.lint.detector.api.Issue
 import net.grandcentrix.thirtyinch.lint.detector.MissingViewInCompositeDetector
 import org.assertj.core.api.Assertions.*
 
-private const val NO_WARNINGS = "No warnings."
-
 class MissingViewInCompositeDetectorTest : LintDetectorTest() {
 
     /* Stubbed-out source files */
-
-    private val tiPresenterStub = java(
-            "package net.grandcentrix.thirtyinch;\n" +
-                    "public abstract class TiPresenter<V extends TiView> {\n" +
-                    "}"
-    )
-
-    private val tiViewStub = java(
-            "package net.grandcentrix.thirtyinch;\n" +
-                    "public interface TiView {\n" +
-                    "}"
-    )
 
     private val caBasePluginStub = java(
             "package com.pascalwelsch.compositeandroid;\n" +

--- a/thirtyinch-lint/src/test/kotlin/net/grandcentrix/thirtyinch/lint/MissingViewInThirtyInchDetectorTest.kt
+++ b/thirtyinch-lint/src/test/kotlin/net/grandcentrix/thirtyinch/lint/MissingViewInThirtyInchDetectorTest.kt
@@ -6,35 +6,9 @@ import com.android.tools.lint.detector.api.Issue
 import net.grandcentrix.thirtyinch.lint.detector.MissingViewInThirtyInchDetector
 import org.assertj.core.api.Assertions.*
 
-private const val NO_WARNINGS = "No warnings."
-
 class MissingViewInThirtyInchDetectorTest : LintDetectorTest() {
 
     /* Stubbed-out source files */
-
-    private val tiActivityStub = java(
-            "package net.grandcentrix.thirtyinch;\n" +
-                    "public abstract class TiActivity<P extends TiPresenter<V>, V extends TiView> {\n" +
-                    "}"
-    )
-
-    private val tiFragmentStub = java(
-            "package net.grandcentrix.thirtyinch;\n" +
-                    "public abstract class TiFragment<P extends TiPresenter<V>, V extends TiView> {\n" +
-                    "}"
-    )
-
-    private val tiPresenterStub = java(
-            "package net.grandcentrix.thirtyinch;\n" +
-                    "public abstract class TiPresenter<V extends TiView> {\n" +
-                    "}"
-    )
-
-    private val tiViewStub = java(
-            "package net.grandcentrix.thirtyinch;\n" +
-                    "public interface TiView {\n" +
-                    "}"
-    )
 
     private val view = java(
             "package foo;\n" +

--- a/thirtyinch-lint/src/test/kotlin/net/grandcentrix/thirtyinch/lint/TiLintRegistryTest.kt
+++ b/thirtyinch-lint/src/test/kotlin/net/grandcentrix/thirtyinch/lint/TiLintRegistryTest.kt
@@ -1,5 +1,6 @@
 package net.grandcentrix.thirtyinch.lint
 
+import net.grandcentrix.thirtyinch.lint.detector.GetViewOrThrowInOnAttachDetector
 import net.grandcentrix.thirtyinch.lint.detector.MissingViewInCompositeDetector
 import net.grandcentrix.thirtyinch.lint.detector.MissingViewInThirtyInchDetector
 import org.assertj.core.api.Assertions.*
@@ -12,7 +13,8 @@ class IssueRegistryTest {
         assertThat(TiLintRegistry().issues)
                 .containsExactly(
                         MissingViewInThirtyInchDetector.ISSUE,
-                        MissingViewInCompositeDetector.ISSUE
+                        MissingViewInCompositeDetector.ISSUE,
+                        GetViewOrThrowInOnAttachDetector.ISSUE
                 )
     }
 }


### PR DESCRIPTION
## Description
This PR implements a new lint check to detect a direct or transitive call of `TiPresenter.getViewOrThrow()` in `TiPresenter.onAttachView()`.

In `TiPresenter.onAttachView()` the view of the presenter might still be null. So calling `TiPresenter.getViewOrThrow()` would throw an exception during runtime.
In production this usually crashes the App. This behaviour is correct to detect the issue later on.

With this lint check the issue can be easily detected already during development.

## Merge Information
Merge after #158 as this PR uses the Lint Check implementation of #158 as foundation.