### PR TITLE
Bugfix: Lint Checks not Triggering

### DIFF
--- a/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/TiLintRegistry.kt
+++ b/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/TiLintRegistry.kt
@@ -16,5 +16,10 @@ class TiLintRegistry : IssueRegistry() {
                 }
         )
 
-    override val api: Int = com.android.tools.lint.detector.api.CURRENT_API
+    /**
+     * Lint API Version for which the Checks are build.
+     *
+     * See [com.android.tools.lint.detector.api.describeApi] for possible options
+     */
+    override val api: Int = 1
 }

--- a/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/detector/BaseMissingViewDetector.kt
+++ b/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/detector/BaseMissingViewDetector.kt
@@ -73,6 +73,9 @@ abstract class BaseMissingViewDetector : Detector(), Detector.UastScanner {
                 return tryFindViewImplementation(context, uastContext.getClass(resolvedType), viewInterface)
             }
         }
-        return false
+
+        val superClass = declaration.superClass
+
+        return superClass != null && tryFindViewImplementation(context, superClass, viewInterface)
     }
 }

--- a/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/detector/MissingViewInThirtyInchDetector.kt
+++ b/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/detector/MissingViewInThirtyInchDetector.kt
@@ -53,6 +53,9 @@ class MissingViewInThirtyInchDetector : BaseMissingViewDetector() {
                             .firstOrNull()
                             ?: (type as? PsiClassType)?.let { tryFindViewInterface(it) }
                 }
+                ?: extendedType.superTypes.firstNotNullResult { superType ->
+                    (superType as? PsiClassType)?.let { tryFindViewInterface(it) }
+                }
     }
 
     override fun allowMissingViewInterface(context: JavaContext, declaration: UClass,

--- a/thirtyinch-lint/src/test/kotlin/net/grandcentrix/thirtyinch/lint/MissingViewInThirtyInchDetectorTest.kt
+++ b/thirtyinch-lint/src/test/kotlin/net/grandcentrix/thirtyinch/lint/MissingViewInThirtyInchDetectorTest.kt
@@ -457,6 +457,226 @@ class MissingViewInThirtyInchDetectorTest : LintDetectorTest() {
         ).isEqualTo(NO_WARNINGS)
     }
 
+    fun testJava_Activity_throughTransitiveBaseClass_withBasePresenter_withBaseView_noWarning() {
+        val baseView = java(
+                "package foo;\n" +
+                        "import net.grandcentrix.thirtyinch.*;\n" +
+                        "interface BaseView extends TiView {\n" +
+                        "}"
+        )
+
+        val basePresenter = java(
+                "package foo;\n" +
+                        "import net.grandcentrix.thirtyinch.*;\n" +
+                        "abstract class BasePresenter<V extends BaseView> extends TiPresenter<V> {\n" +
+                        "}"
+        )
+
+        val baseActivity = java(
+                "package foo;\n" +
+                        "import net.grandcentrix.thirtyinch.*;\n" +
+                        "abstract class BaseActivity<P extends BasePresenter<V>, V extends BaseView> extends TiActivity<P, V> {\n" +
+                        "}"
+        )
+
+        val activity = java(
+                "package foo;\n" +
+                        "class InformationActivity extends BaseActivity<MyPresenter, MyView> implements MyView {\n" +
+                        "}"
+        )
+
+        val view = java(
+                "package foo;\n" +
+                        "interface MyView extends BaseView {\n" +
+                        "}"
+        )
+
+        val customPresenter = java(
+                "package foo;\n" +
+                        "class MyPresenter extends BasePresenter<MyView> {\n" +
+                        "}"
+        )
+
+        assertThat(
+                lintProject(
+                        tiActivityStub,
+                        tiPresenterStub,
+                        tiViewStub,
+                        baseView,
+                        view,
+                        basePresenter,
+                        customPresenter,
+                        baseActivity,
+                        activity
+                )
+        ).isEqualTo(NO_WARNINGS)
+    }
+
+    fun testKotlin_Activity_throughTransitiveBaseClass_withBasePresenter_withBaseView_noWarning() {
+        val baseView = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.*\n" +
+                        "interface BaseView : TiView {\n" +
+                        "}"
+        )
+
+        val basePresenter = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.*\n" +
+                        "abstract class BasePresenter<V : BaseView> : TiPresenter<V>() {\n" +
+                        "}"
+        )
+
+        val baseActivity = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.*\n" +
+                        "abstract class BaseActivity<P : BasePresenter<V>, V : BaseView> : TiActivity<P, V>(), MyView {\n" +
+                        "}"
+        )
+
+        val activity = kotlin(
+                "package foo\n" +
+                        "class InformationActivity : BaseActivity<MyPresenter, MyView>() {\n" +
+                        "}"
+        )
+
+        val view = kotlin(
+                "package foo\n" +
+                        "interface MyView : BaseView {\n" +
+                        "}"
+        )
+
+        val customPresenter = kotlin(
+                "package foo\n" +
+                        "class MyPresenter : BasePresenter<MyView>() {\n" +
+                        "}"
+        )
+
+        assertThat(
+                lintProject(
+                        tiActivityStub,
+                        tiPresenterStub,
+                        tiViewStub,
+                        baseView,
+                        view,
+                        basePresenter,
+                        customPresenter,
+                        baseActivity,
+                        activity
+                )
+        ).isEqualTo(NO_WARNINGS)
+    }
+
+    fun testJava_Activity_throughTransitiveBaseClass_withBasePresenter_withBaseView_hasWarning() {
+        val baseView = java(
+                "package foo;\n" +
+                        "import net.grandcentrix.thirtyinch.*;\n" +
+                        "interface BaseView extends TiView {\n" +
+                        "}"
+        )
+
+        val basePresenter = java(
+                "package foo;\n" +
+                        "import net.grandcentrix.thirtyinch.*;\n" +
+                        "abstract class BasePresenter<V extends BaseView> extends TiPresenter<V> {\n" +
+                        "}"
+        )
+
+        val baseActivity = java(
+                "package foo;\n" +
+                        "import net.grandcentrix.thirtyinch.*;\n" +
+                        "abstract class BaseActivity<P extends BasePresenter<V>, V extends BaseView> extends TiActivity<P, V> {\n" +
+                        "}"
+        )
+
+        val activity = java(
+                "package foo;\n" +
+                        "class InformationActivity extends BaseActivity<MyPresenter, MyView> {\n" +
+                        "}"
+        )
+
+        val view = java(
+                "package foo;\n" +
+                        "interface MyView extends BaseView {\n" +
+                        "}"
+        )
+
+        val customPresenter = java(
+                "package foo;\n" +
+                        "class MyPresenter extends BasePresenter<MyView> {\n" +
+                        "}"
+        )
+
+        assertThat(
+                lintProject(
+                        tiActivityStub,
+                        tiPresenterStub,
+                        tiViewStub,
+                        baseView,
+                        view,
+                        basePresenter,
+                        customPresenter,
+                        baseActivity,
+                        activity
+                )
+        ).containsOnlyOnce(TiIssue.MissingView.id)
+    }
+
+    fun testKotlin_Activity_throughTransitiveBaseClass_withBasePresenter_withBaseView_hasWarning() {
+        val baseView = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.*\n" +
+                        "interface BaseView : TiView {\n" +
+                        "}"
+        )
+
+        val basePresenter = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.*\n" +
+                        "abstract class BasePresenter<V : BaseView> : TiPresenter<V>() {\n" +
+                        "}"
+        )
+
+        val baseActivity = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.*\n" +
+                        "abstract class BaseActivity<P : BasePresenter<V>, V : BaseView> : TiActivity<P, V>() {\n" +
+                        "}"
+        )
+
+        val activity = kotlin(
+                "package foo\n" +
+                        "class InformationActivity : BaseActivity<MyPresenter, MyView>() {\n" +
+                        "}"
+        )
+
+        val view = kotlin(
+                "package foo\n" +
+                        "interface MyView : BaseView {\n" +
+                        "}"
+        )
+
+        val customPresenter = kotlin(
+                "package foo\n" +
+                        "class MyPresenter : BasePresenter<MyView>() {\n" +
+                        "}"
+        )
+
+        assertThat(
+                lintProject(
+                        tiActivityStub,
+                        tiPresenterStub,
+                        tiViewStub,
+                        baseView,
+                        view,
+                        basePresenter,
+                        customPresenter,
+                        baseActivity,
+                        activity
+                )
+        ).containsOnlyOnce(TiIssue.MissingView.id)
+    }
+
     fun testKotlin_Activity_throughBaseClass_noWarning() {
         val baseActivity = kotlin(
                 "package foo;\n" +
@@ -488,7 +708,7 @@ class MissingViewInThirtyInchDetectorTest : LintDetectorTest() {
         val baseActivity = kotlin(
                 "package foo;\n" +
                         "import net.grandcentrix.thirtyinch.*;\n" +
-                        "public class BaseActivity : TiActivity<TiPresenter<MyView>, MyView>() {\n" +
+                        "public abstract class BaseActivity : TiActivity<TiPresenter<MyView>, MyView>() {\n" +
                         "}"
         )
 
@@ -825,7 +1045,7 @@ class MissingViewInThirtyInchDetectorTest : LintDetectorTest() {
         val baseFragment = kotlin(
                 "package foo\n" +
                         "import net.grandcentrix.thirtyinch.*\n" +
-                        "class BaseFragment : TiFragment<TiPresenter<MyView>, MyView>() {\n" +
+                        "abstract class BaseFragment : TiFragment<TiPresenter<MyView>, MyView>() {\n" +
                         "}"
         )
 


### PR DESCRIPTION
### Description
This PR will solve a couple of issues with the implemented Lint Checks for TI.
1) **TI Lint Checks are not executed prior Build Tools 3.3** Caused by the lately increased the Build Tools version and so the Lint API Version while using `com.android.tools.lint.detector.api.CURRENT_API` as Lint Version. So the checks when marked as not compatible with the Build Tools used.
2) **Check if provideView() is overridden always returns true** Caused by the fact that this check was checking the whole inheritance tree and so found the implementation in the TI base classes.
3) **Check if the View Interface is implemented did not check more than the direct super class**

### How to Test
Play with the following scenarios:
- Remove the `implements HelloWorldView` in the `HelloWorldActivity` of the sample app
- Remove the `implements HelloWorldView` but override `provideView()` in the `HelloWorldActivity` of the sample app
- Use TI v`0.10.0-SNAPSHOT` of this branch in another project and have an TiActivity which does not implement the given `TiView` subclass

### Note
Testing Lint Checks in the Sample Project did not work reliably for me. This seems to be an Android Studio Issue as quite often an `Invalidate Caches and Restart` help.
A commandline lint run were reporting the errors reliably.