### PR TITLE
Feature: Annotation Lint Checks

### DIFF
--- a/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/TiIssue.kt
+++ b/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/TiIssue.kt
@@ -12,6 +12,7 @@ private val CATEGORY_TI = Category.create("ThirtyInch", 90)
 sealed class TiIssue(
         val id: String,
         val briefDescription: String,
+        val longDescription: String = briefDescription,
         val category: Category,
         val priority: Int,
         val severity: Severity
@@ -25,11 +26,29 @@ sealed class TiIssue(
             severity = Severity.ERROR
     )
 
-    fun asLintIssue(detectorCls: Class<out Detector>, description: String = briefDescription): Issue =
+    object DistinctUntilChangedWithoutParameter : TiIssue(
+            id = "DistinctUntilChangedWithoutParameter",
+            briefDescription = "@DistinctUntilChanged Annotation on a method without Parameter is useless",
+            longDescription = "When using the @DistinctUntilChanged annotation on a method without parameter the method call will be executed each time. @DistinctUntilChanged needs at least one parameter to check if it changed compared to the last method invocation.",
+            category = CATEGORY_TI,
+            priority = 5,
+            severity = Severity.WARNING
+    )
+
+    object AnnotationOnNonVoidMethod : TiIssue(
+            id = "TiAnnotationOnNonVoidMethod",
+            briefDescription = "Annotation of a non Void method is not supported in ThirtyInch",
+            longDescription = "When using a ThirtyInch annotation on a method without parameter the method call will be executed each time. Return types are not supported.",
+            category = CATEGORY_TI,
+            priority = 5,
+            severity = Severity.WARNING
+    )
+
+    fun asLintIssue(detectorCls: Class<out Detector>, description: String? = null): Issue =
             Issue.create(
                     id,
                     briefDescription,
-                    description,
+                    description ?: longDescription,
                     category,
                     priority,
                     severity,

--- a/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/TiIssue.kt
+++ b/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/TiIssue.kt
@@ -44,6 +44,15 @@ sealed class TiIssue(
             severity = Severity.WARNING
     )
 
+    object AnnotationOnNonTiView : TiIssue(
+            id = "TiAnnotationOnNonTiViewInterface",
+            briefDescription = "ThirtyInch Annotations on a method of a not TiView Interface is useless",
+            longDescription = "When using a ThirtyInch annotation on a method of a not TiView Interface it will not be recognized and so will not change anything.",
+            category = CATEGORY_TI,
+            priority = 5,
+            severity = Severity.WARNING
+    )
+
     fun asLintIssue(detectorCls: Class<out Detector>, description: String? = null): Issue =
             Issue.create(
                     id,

--- a/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/TiLintRegistry.kt
+++ b/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/TiLintRegistry.kt
@@ -16,5 +16,10 @@ class TiLintRegistry : IssueRegistry() {
                 }
         )
 
-    override val api: Int = com.android.tools.lint.detector.api.CURRENT_API
+    /**
+     * Lint API Version for which the Checks are build.
+     *
+     * See [com.android.tools.lint.detector.api.describeApi] for possible options
+     */
+    override val api: Int = 1
 }

--- a/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/TiLintRegistry.kt
+++ b/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/TiLintRegistry.kt
@@ -20,6 +20,9 @@ class TiLintRegistry : IssueRegistry() {
                 },
                 DistinctUntilChangedUsageDetector.ISSUE_NON_VOID_RETURN_TYPE.apply {
                     setEnabledByDefault(true)
+                },
+                DistinctUntilChangedUsageDetector.ISSUE_NO_TIVIEW_CHILD.apply {
+                    setEnabledByDefault(true)
                 }
         )
 

--- a/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/TiLintRegistry.kt
+++ b/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/TiLintRegistry.kt
@@ -2,6 +2,7 @@ package net.grandcentrix.thirtyinch.lint
 
 import com.android.tools.lint.client.api.IssueRegistry
 import com.android.tools.lint.detector.api.Issue
+import net.grandcentrix.thirtyinch.lint.detector.CallOnMainThreadUsageDetector
 import net.grandcentrix.thirtyinch.lint.detector.DistinctUntilChangedUsageDetector
 import net.grandcentrix.thirtyinch.lint.detector.MissingViewInCompositeDetector
 import net.grandcentrix.thirtyinch.lint.detector.MissingViewInThirtyInchDetector
@@ -22,6 +23,12 @@ class TiLintRegistry : IssueRegistry() {
                     setEnabledByDefault(true)
                 },
                 DistinctUntilChangedUsageDetector.ISSUE_NO_TIVIEW_CHILD.apply {
+                    setEnabledByDefault(true)
+                },
+                CallOnMainThreadUsageDetector.ISSUE_NON_VOID_RETURN_TYPE.apply {
+                    setEnabledByDefault(true)
+                },
+                CallOnMainThreadUsageDetector.ISSUE_NO_TIVIEW_CHILD.apply {
                     setEnabledByDefault(true)
                 }
         )

--- a/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/TiLintRegistry.kt
+++ b/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/TiLintRegistry.kt
@@ -2,6 +2,7 @@ package net.grandcentrix.thirtyinch.lint
 
 import com.android.tools.lint.client.api.IssueRegistry
 import com.android.tools.lint.detector.api.Issue
+import net.grandcentrix.thirtyinch.lint.detector.DistinctUntilChangedUsageDetector
 import net.grandcentrix.thirtyinch.lint.detector.MissingViewInCompositeDetector
 import net.grandcentrix.thirtyinch.lint.detector.MissingViewInThirtyInchDetector
 
@@ -12,6 +13,12 @@ class TiLintRegistry : IssueRegistry() {
                     setEnabledByDefault(true)
                 },
                 MissingViewInCompositeDetector.ISSUE.apply {
+                    setEnabledByDefault(true)
+                },
+                DistinctUntilChangedUsageDetector.ISSUE_NO_PARAMETER.apply {
+                    setEnabledByDefault(true)
+                },
+                DistinctUntilChangedUsageDetector.ISSUE_NON_VOID_RETURN_TYPE.apply {
                     setEnabledByDefault(true)
                 }
         )

--- a/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/detector/BaseMissingViewDetector.kt
+++ b/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/detector/BaseMissingViewDetector.kt
@@ -73,6 +73,9 @@ abstract class BaseMissingViewDetector : Detector(), Detector.UastScanner {
                 return tryFindViewImplementation(context, uastContext.getClass(resolvedType), viewInterface)
             }
         }
-        return false
+
+        val superClass = declaration.superClass
+
+        return superClass != null && tryFindViewImplementation(context, superClass, viewInterface)
     }
 }

--- a/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/detector/CallOnMainThreadUsageDetector.kt
+++ b/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/detector/CallOnMainThreadUsageDetector.kt
@@ -1,0 +1,65 @@
+package net.grandcentrix.thirtyinch.lint.detector
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Detector.UastScanner
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.TextFormat.TEXT
+import com.intellij.psi.PsiType
+import net.grandcentrix.thirtyinch.lint.TiIssue
+import org.jetbrains.uast.UAnnotation
+import org.jetbrains.uast.UClass
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UMethod
+import org.jetbrains.uast.getContainingUClass
+import org.jetbrains.uast.toUElement
+
+private const val FQN_CLASS_TIVIEW = "net.grandcentrix.thirtyinch.TiView"
+private const val FQN_ANNOTATION_CALLONMAINTHREAD = "net.grandcentrix.thirtyinch.callonmainthread.CallOnMainThread"
+
+class CallOnMainThreadUsageDetector : Detector(), UastScanner {
+    companion object {
+        val ISSUE_NON_VOID_RETURN_TYPE = TiIssue.AnnotationOnNonVoidMethod.asLintIssue(
+                detectorCls = CallOnMainThreadUsageDetector::class.java
+        )
+        val ISSUE_NO_TIVIEW_CHILD = TiIssue.AnnotationOnNonTiView.asLintIssue(
+                detectorCls = CallOnMainThreadUsageDetector::class.java
+        )
+    }
+
+    override fun getApplicableUastTypes(): List<Class<out UElement>> = listOf(
+            UAnnotation::class.java
+    )
+
+    override fun createUastHandler(context: JavaContext): UElementHandler = object : UElementHandler() {
+        override fun visitAnnotation(node: UAnnotation) {
+            if (node.qualifiedName != FQN_ANNOTATION_CALLONMAINTHREAD) return
+
+            val method = node.uastParent as? UMethod ?: return
+
+            if (context.isEnabled(ISSUE_NON_VOID_RETURN_TYPE) && method.returnType != PsiType.VOID) {
+                report(context, node, ISSUE_NON_VOID_RETURN_TYPE)
+            }
+
+            if (context.isEnabled(ISSUE_NO_TIVIEW_CHILD)) {
+                val methodClass = method.getContainingUClass()
+                if (methodClass == null || !methodClass.isInterface || !methodClass.extends(FQN_CLASS_TIVIEW)) {
+                    report(context, node, ISSUE_NO_TIVIEW_CHILD)
+                }
+            }
+        }
+    }
+
+    private fun UClass.extends(fqClassName: String): Boolean = qualifiedName == fqClassName ||
+            interfaces.mapNotNull { iFace -> iFace.toUElement() as? UClass }
+                    .any { iFace -> iFace.extends(fqClassName) }
+
+    private fun report(context: JavaContext, annotation: UAnnotation, issue: Issue) {
+        context.report(
+                issue,
+                context.getLocation(annotation),
+                issue.getBriefDescription(TEXT)
+        )
+    }
+}

--- a/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/detector/DistinctUntilChangedUsageDetector.kt
+++ b/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/detector/DistinctUntilChangedUsageDetector.kt
@@ -3,8 +3,9 @@ package net.grandcentrix.thirtyinch.lint.detector
 import com.android.tools.lint.client.api.UElementHandler
 import com.android.tools.lint.detector.api.Detector
 import com.android.tools.lint.detector.api.Detector.UastScanner
+import com.android.tools.lint.detector.api.Issue
 import com.android.tools.lint.detector.api.JavaContext
-import com.android.tools.lint.detector.api.TextFormat
+import com.android.tools.lint.detector.api.TextFormat.TEXT
 import com.intellij.psi.PsiType
 import net.grandcentrix.thirtyinch.lint.TiIssue
 import org.jetbrains.uast.UAnnotation
@@ -34,20 +35,20 @@ class DistinctUntilChangedUsageDetector : Detector(), UastScanner {
             val method = node.uastParent as? UMethod ?: return
 
             if (!method.hasParameters()) {
-                context.report(
-                        ISSUE_NO_PARAMETER,
-                        context.getLocation(node),
-                        ISSUE_NO_PARAMETER.getBriefDescription(TextFormat.TEXT)
-                )
+                report(context, node, ISSUE_NO_PARAMETER)
             }
-            
+
             if (method.returnType != PsiType.VOID) {
-                context.report(
-                        ISSUE_NON_VOID_RETURN_TYPE,
-                        context.getLocation(node),
-                        ISSUE_NON_VOID_RETURN_TYPE.getBriefDescription(TextFormat.TEXT)
-                )
+                report(context, node, ISSUE_NON_VOID_RETURN_TYPE)
             }
         }
+    }
+
+    private fun report(context: JavaContext, annotation: UAnnotation, issue: Issue) {
+        context.report(
+                issue,
+                context.getLocation(annotation),
+                issue.getBriefDescription(TEXT)
+        )
     }
 }

--- a/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/detector/DistinctUntilChangedUsageDetector.kt
+++ b/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/detector/DistinctUntilChangedUsageDetector.kt
@@ -1,0 +1,54 @@
+package net.grandcentrix.thirtyinch.lint.detector
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Detector.UastScanner
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.TextFormat
+import com.intellij.psi.PsiType
+import net.grandcentrix.thirtyinch.lint.TiIssue
+import org.jetbrains.uast.UAnnotation
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UMethod
+
+private const val FQN_ANNOTATION_DISTINCTUNTILCHANGED = "net.grandcentrix.thirtyinch.distinctuntilchanged.DistinctUntilChanged"
+
+class DistinctUntilChangedUsageDetector : Detector(), UastScanner {
+    companion object {
+        val ISSUE_NO_PARAMETER = TiIssue.DistinctUntilChangedWithoutParameter.asLintIssue(
+                detectorCls = DistinctUntilChangedUsageDetector::class.java
+        )
+        val ISSUE_NON_VOID_RETURN_TYPE = TiIssue.AnnotationOnNonVoidMethod.asLintIssue(
+                detectorCls = DistinctUntilChangedUsageDetector::class.java
+        )
+    }
+
+    override fun getApplicableUastTypes(): List<Class<out UElement>> = listOf(
+            UAnnotation::class.java
+    )
+
+    override fun createUastHandler(context: JavaContext): UElementHandler = object : UElementHandler() {
+        override fun visitAnnotation(node: UAnnotation) {
+            if (node.qualifiedName != FQN_ANNOTATION_DISTINCTUNTILCHANGED) return
+
+            val method = node.uastParent as? UMethod ?: return
+
+            when {
+                !method.hasParameters() -> {
+                    context.report(
+                            ISSUE_NO_PARAMETER,
+                            context.getLocation(node),
+                            ISSUE_NO_PARAMETER.getBriefDescription(TextFormat.TEXT)
+                    )
+                }
+                method.returnType != PsiType.VOID -> {
+                    context.report(
+                            ISSUE_NON_VOID_RETURN_TYPE,
+                            context.getLocation(node),
+                            ISSUE_NON_VOID_RETURN_TYPE.getBriefDescription(TextFormat.TEXT)
+                    )
+                }
+            }
+        }
+    }
+}

--- a/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/detector/DistinctUntilChangedUsageDetector.kt
+++ b/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/detector/DistinctUntilChangedUsageDetector.kt
@@ -34,11 +34,11 @@ class DistinctUntilChangedUsageDetector : Detector(), UastScanner {
 
             val method = node.uastParent as? UMethod ?: return
 
-            if (!method.hasParameters()) {
+            if (context.isEnabled(ISSUE_NO_PARAMETER) && !method.hasParameters()) {
                 report(context, node, ISSUE_NO_PARAMETER)
             }
 
-            if (method.returnType != PsiType.VOID) {
+            if (context.isEnabled(ISSUE_NON_VOID_RETURN_TYPE) && method.returnType != PsiType.VOID) {
                 report(context, node, ISSUE_NON_VOID_RETURN_TYPE)
             }
         }

--- a/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/detector/DistinctUntilChangedUsageDetector.kt
+++ b/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/detector/DistinctUntilChangedUsageDetector.kt
@@ -33,21 +33,20 @@ class DistinctUntilChangedUsageDetector : Detector(), UastScanner {
 
             val method = node.uastParent as? UMethod ?: return
 
-            when {
-                !method.hasParameters() -> {
-                    context.report(
-                            ISSUE_NO_PARAMETER,
-                            context.getLocation(node),
-                            ISSUE_NO_PARAMETER.getBriefDescription(TextFormat.TEXT)
-                    )
-                }
-                method.returnType != PsiType.VOID -> {
-                    context.report(
-                            ISSUE_NON_VOID_RETURN_TYPE,
-                            context.getLocation(node),
-                            ISSUE_NON_VOID_RETURN_TYPE.getBriefDescription(TextFormat.TEXT)
-                    )
-                }
+            if (!method.hasParameters()) {
+                context.report(
+                        ISSUE_NO_PARAMETER,
+                        context.getLocation(node),
+                        ISSUE_NO_PARAMETER.getBriefDescription(TextFormat.TEXT)
+                )
+            }
+            
+            if (method.returnType != PsiType.VOID) {
+                context.report(
+                        ISSUE_NON_VOID_RETURN_TYPE,
+                        context.getLocation(node),
+                        ISSUE_NON_VOID_RETURN_TYPE.getBriefDescription(TextFormat.TEXT)
+                )
             }
         }
     }

--- a/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/detector/MissingViewInThirtyInchDetector.kt
+++ b/thirtyinch-lint/src/main/kotlin/net/grandcentrix/thirtyinch/lint/detector/MissingViewInThirtyInchDetector.kt
@@ -53,6 +53,9 @@ class MissingViewInThirtyInchDetector : BaseMissingViewDetector() {
                             .firstOrNull()
                             ?: (type as? PsiClassType)?.let { tryFindViewInterface(it) }
                 }
+                ?: extendedType.superTypes.firstNotNullResult { superType ->
+                    (superType as? PsiClassType)?.let { tryFindViewInterface(it) }
+                }
     }
 
     override fun allowMissingViewInterface(context: JavaContext, declaration: UClass,

--- a/thirtyinch-lint/src/test/kotlin/net/grandcentrix/thirtyinch/lint/CallOnMainThreadUsageDetectorTest.kt
+++ b/thirtyinch-lint/src/test/kotlin/net/grandcentrix/thirtyinch/lint/CallOnMainThreadUsageDetectorTest.kt
@@ -1,0 +1,221 @@
+package net.grandcentrix.thirtyinch.lint
+
+import com.android.tools.lint.checks.infrastructure.LintDetectorTest
+import com.android.tools.lint.checks.infrastructure.LintDetectorTest.java
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Issue
+import net.grandcentrix.thirtyinch.lint.detector.CallOnMainThreadUsageDetector
+import org.assertj.core.api.Assertions
+
+private const val NO_WARNINGS = "No warnings."
+
+private val CLASS_CALLONMAINTHREAD = java(
+        "package net.grandcentrix.thirtyinch.callonmainthread;\n" +
+                "\n" +
+                "import java.lang.annotation.Documented;\n" +
+                "import java.lang.annotation.ElementType;\n" +
+                "import java.lang.annotation.Retention;\n" +
+                "import java.lang.annotation.RetentionPolicy;\n" +
+                "import java.lang.annotation.Target;\n" +
+                "\n" +
+                "@Documented\n" +
+                "@Target(ElementType.METHOD)\n" +
+                "@Retention(RetentionPolicy.RUNTIME)\n" +
+                "public @interface CallOnMainThread {\n" +
+                "}"
+)
+
+private val CLASS_TIVIEW = java(
+        "package net.grandcentrix.thirtyinch;\n" +
+                "public interface TiView {}"
+)
+
+class CallOnMainThreadUsageDetectorTest : LintDetectorTest() {
+
+    override fun getDetector(): Detector = CallOnMainThreadUsageDetector()
+
+    override fun getIssues(): List<Issue> = listOf(
+            CallOnMainThreadUsageDetector.ISSUE_NON_VOID_RETURN_TYPE,
+            CallOnMainThreadUsageDetector.ISSUE_NO_TIVIEW_CHILD
+    )
+
+    fun testJava_annotation_used_on_method_with_non_void_return_type_should_have_warning() {
+        val testInterface = java(
+                "package foo;\n" +
+                        "import net.grandcentrix.thirtyinch.callonmainthread.CallOnMainThread;\n" +
+                        "import net.grandcentrix.thirtyinch.TiView;\n" +
+                        "public interface MyInterface extends TiView {\n" +
+                        "   @CallOnMainThread\n" +
+                        "   public int test(String id);\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(lintProject(CLASS_TIVIEW, CLASS_CALLONMAINTHREAD, testInterface))
+                .containsOnlyOnce(TiIssue.AnnotationOnNonVoidMethod.id)
+    }
+
+    fun testKotlin_annotation_used_on_method_with_non_void_return_type_should_have_warning() {
+        val testInterface = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.callonmainthread.CallOnMainThread\n" +
+                        "import net.grandcentrix.thirtyinch.TiView\n" +
+                        "interface MyInterface : TiView {\n" +
+                        "   @CallOnMainThread\n" +
+                        "   fun test(id: String): Int\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(lintProject(CLASS_TIVIEW, CLASS_CALLONMAINTHREAD, testInterface))
+                .containsOnlyOnce(TiIssue.AnnotationOnNonVoidMethod.id)
+    }
+
+    fun testJava_annotation_used_on_method_with_void_return_type_should_have_no_warning() {
+        val testInterface = java(
+                "package foo;\n" +
+                        "import net.grandcentrix.thirtyinch.callonmainthread.CallOnMainThread;\n" +
+                        "import net.grandcentrix.thirtyinch.TiView;\n" +
+                        "public interface MyInterface extends TiView {\n" +
+                        "   @CallOnMainThread\n" +
+                        "   public void test(String id);\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(lintProject(CLASS_TIVIEW, CLASS_CALLONMAINTHREAD, testInterface))
+                .isEqualTo(NO_WARNINGS)
+    }
+
+    fun testKotlin_annotation_used_on_method_with_void_return_type_should_have_no_warning() {
+        val testInterface = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.callonmainthread.CallOnMainThread\n" +
+                        "import net.grandcentrix.thirtyinch.TiView\n" +
+                        "interface MyInterface : TiView {\n" +
+                        "   @CallOnMainThread\n" +
+                        "   fun test(id: String)\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(lintProject(CLASS_TIVIEW, CLASS_CALLONMAINTHREAD, testInterface))
+                .isEqualTo(NO_WARNINGS)
+    }
+
+    fun testJava_annotation_used_on_method_in_TiView_child_interface_should_have_no_warning() {
+        val testInterface = java(
+                "package foo;\n" +
+                        "import net.grandcentrix.thirtyinch.callonmainthread.CallOnMainThread;\n" +
+                        "import net.grandcentrix.thirtyinch.TiView;\n" +
+                        "public interface MyInterface extends TiView {\n" +
+                        "   @CallOnMainThread\n" +
+                        "   public void test(String id);\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(lintProject(CLASS_TIVIEW, CLASS_CALLONMAINTHREAD, testInterface))
+                .isEqualTo(NO_WARNINGS)
+    }
+
+    fun testKotlin_annotation_used_on_method_in_TiView_child_interface_should_have_no_warning() {
+        val testInterface = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.callonmainthread.CallOnMainThread\n" +
+                        "import net.grandcentrix.thirtyinch.TiView\n" +
+                        "interface MyInterface : TiView {\n" +
+                        "   @CallOnMainThread\n" +
+                        "   fun test(id: String)\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(lintProject(CLASS_TIVIEW, CLASS_CALLONMAINTHREAD, testInterface))
+                .isEqualTo(NO_WARNINGS)
+    }
+
+    fun testJava_annotation_used_on_method_in_TiView_child_class_should_have_warning() {
+        val testInterface = java(
+                "package foo;\n" +
+                        "import net.grandcentrix.thirtyinch.callonmainthread.CallOnMainThread;\n" +
+                        "import net.grandcentrix.thirtyinch.TiView;\n" +
+                        "public class MyClass extends TiView {\n" +
+                        "   @CallOnMainThread\n" +
+                        "   public void test(String id);\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(lintProject(CLASS_TIVIEW, CLASS_CALLONMAINTHREAD, testInterface))
+                .containsOnlyOnce(TiIssue.AnnotationOnNonTiView.id)
+    }
+
+    fun testKotlin_annotation_used_on_method_in_TiView_child_class_should_have_warning() {
+        val testInterface = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.callonmainthread.CallOnMainThread\n" +
+                        "import net.grandcentrix.thirtyinch.TiView\n" +
+                        "class MyClass : TiView {\n" +
+                        "   @CallOnMainThread\n" +
+                        "   fun test(id: String)\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(lintProject(CLASS_TIVIEW, CLASS_CALLONMAINTHREAD, testInterface))
+                .containsOnlyOnce(TiIssue.AnnotationOnNonTiView.id)
+    }
+
+    fun testJava_annotation_used_on_method_in_non_TiView_child_class_should_have_warning() {
+        val testInterface = java(
+                "package foo;\n" +
+                        "import net.grandcentrix.thirtyinch.callonmainthread.CallOnMainThread;\n" +
+                        "import net.grandcentrix.thirtyinch.TiView;\n" +
+                        "public class MyClass {\n" +
+                        "   @CallOnMainThread\n" +
+                        "   public void test(String id);\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(lintProject(CLASS_CALLONMAINTHREAD, testInterface))
+                .containsOnlyOnce(TiIssue.AnnotationOnNonTiView.id)
+    }
+
+    fun testKotlin_annotation_used_on_method_in_non_TiView_child_class_should_have_warning() {
+        val testInterface = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.callonmainthread.CallOnMainThread\n" +
+                        "import net.grandcentrix.thirtyinch.TiView\n" +
+                        "class MyClass {\n" +
+                        "   @CallOnMainThread\n" +
+                        "   fun test(id: String)\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(lintProject(CLASS_CALLONMAINTHREAD, testInterface))
+                .containsOnlyOnce(TiIssue.AnnotationOnNonTiView.id)
+    }
+
+    fun testJava_annotation_used_on_method_in_non_TiView_interface_class_should_have_warning() {
+        val testInterface = java(
+                "package foo;\n" +
+                        "import net.grandcentrix.thirtyinch.callonmainthread.CallOnMainThread;\n" +
+                        "import net.grandcentrix.thirtyinch.TiView;\n" +
+                        "public interface MyView {\n" +
+                        "   @CallOnMainThread\n" +
+                        "   public void test(String id);\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(lintProject(CLASS_CALLONMAINTHREAD, testInterface))
+                .containsOnlyOnce(TiIssue.AnnotationOnNonTiView.id)
+    }
+
+    fun testKotlin_annotation_used_on_method_in_non_TiView_interface_class_should_have_warning() {
+        val testInterface = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.callonmainthread.CallOnMainThread\n" +
+                        "import net.grandcentrix.thirtyinch.TiView\n" +
+                        "interface MyClass {\n" +
+                        "   @CallOnMainThread\n" +
+                        "   fun test(id: String)\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(lintProject(CLASS_CALLONMAINTHREAD, testInterface))
+                .containsOnlyOnce(TiIssue.AnnotationOnNonTiView.id)
+    }
+}

--- a/thirtyinch-lint/src/test/kotlin/net/grandcentrix/thirtyinch/lint/DistinctUntilChangedUsageDetectorTest.kt
+++ b/thirtyinch-lint/src/test/kotlin/net/grandcentrix/thirtyinch/lint/DistinctUntilChangedUsageDetectorTest.kt
@@ -1,0 +1,157 @@
+package net.grandcentrix.thirtyinch.lint
+
+import com.android.tools.lint.checks.infrastructure.LintDetectorTest
+import com.android.tools.lint.checks.infrastructure.LintDetectorTest.java
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Issue
+import net.grandcentrix.thirtyinch.lint.detector.DistinctUntilChangedUsageDetector
+import org.assertj.core.api.Assertions
+
+private const val NO_WARNINGS = "No warnings."
+
+private val CLASS_DISTINCTUNTILCHANGED = java(
+        "package net.grandcentrix.thirtyinch.distinctuntilchanged;\n" +
+                "\n" +
+                "import java.lang.annotation.Documented;\n" +
+                "import java.lang.annotation.ElementType;\n" +
+                "import java.lang.annotation.Retention;\n" +
+                "import java.lang.annotation.RetentionPolicy;\n" +
+                "import java.lang.annotation.Target;\n" +
+                "\n" +
+                "@Documented\n" +
+                "@Target(ElementType.METHOD)\n" +
+                "@Retention(RetentionPolicy.RUNTIME)\n" +
+                "public @interface DistinctUntilChanged {\n" +
+                "\n" +
+                "    Class<? extends DistinctComparator> comparator() default HashComparator.class;\n" +
+                "\n" +
+                "    boolean logDropped() default false;\n" +
+                "\n" +
+                "}"
+)
+
+class DistinctUntilChangedUsageDetectorTest : LintDetectorTest() {
+
+    override fun getDetector(): Detector = DistinctUntilChangedUsageDetector()
+
+    override fun getIssues(): MutableList<Issue> = mutableListOf(
+            DistinctUntilChangedUsageDetector.ISSUE_NO_PARAMETER,
+            DistinctUntilChangedUsageDetector.ISSUE_NON_VOID_RETURN_TYPE
+    )
+
+    fun testJava_annotation_used_on_method_without_parameter_should_have_warning() {
+        val testInterface = java(
+                "package foo;\n" +
+                        "import net.grandcentrix.thirtyinch.distinctuntilchanged.DistinctUntilChanged;\n" +
+                        "import net.grandcentrix.thirtyinch.TiView;\n" +
+                        "public interface MyInterface extends TiView {\n" +
+                        "   @DistinctUntilChanged\n" +
+                        "   public void test();\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(lintProject(CLASS_DISTINCTUNTILCHANGED, testInterface))
+                .containsOnlyOnce(TiIssue.DistinctUntilChangedWithoutParameter.id)
+    }
+
+    fun testKotlin_annotation_used_on_method_without_parameter_should_have_warning() {
+        val testInterface = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.distinctuntilchanged.DistinctUntilChanged\n" +
+                        "import net.grandcentrix.thirtyinch.TiView\n" +
+                        "interface MyInterface : TiView {\n" +
+                        "   @DistinctUntilChanged\n" +
+                        "   fun test()\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(lintProject(CLASS_DISTINCTUNTILCHANGED, testInterface))
+                .containsOnlyOnce(TiIssue.DistinctUntilChangedWithoutParameter.id)
+    }
+
+    fun testJava_annotation_used_on_method_with_parameter_should_have_no_warning() {
+        val testInterface = java(
+                "package foo;\n" +
+                        "import net.grandcentrix.thirtyinch.distinctuntilchanged.DistinctUntilChanged;\n" +
+                        "import net.grandcentrix.thirtyinch.TiView;\n" +
+                        "public interface MyInterface extends TiView {\n" +
+                        "   @DistinctUntilChanged\n" +
+                        "   public void test(String id);\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(lintProject(CLASS_DISTINCTUNTILCHANGED, testInterface)).isEqualTo(NO_WARNINGS)
+    }
+
+    fun testKotlin_annotation_used_on_method_with_parameter_should_have_no_warning() {
+        val testInterface = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.distinctuntilchanged.DistinctUntilChanged\n" +
+                        "import net.grandcentrix.thirtyinch.TiView\n" +
+                        "interface MyInterface : TiView {\n" +
+                        "   @DistinctUntilChanged\n" +
+                        "   fun test(id: String)\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(lintProject(CLASS_DISTINCTUNTILCHANGED, testInterface)).isEqualTo(NO_WARNINGS)
+    }
+
+    fun testJava_annotation_used_on_method_with_non_void_return_type_should_have_warning() {
+        val testInterface = java(
+                "package foo;\n" +
+                        "import net.grandcentrix.thirtyinch.distinctuntilchanged.DistinctUntilChanged;\n" +
+                        "import net.grandcentrix.thirtyinch.TiView;\n" +
+                        "public interface MyInterface extends TiView {\n" +
+                        "   @DistinctUntilChanged\n" +
+                        "   public int test(String id);\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(lintProject(CLASS_DISTINCTUNTILCHANGED, testInterface))
+                .containsOnlyOnce(TiIssue.AnnotationOnNonVoidMethod.id)
+    }
+
+    fun testKotlin_annotation_used_on_method_with_non_void_return_type_should_have_warning() {
+        val testInterface = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.distinctuntilchanged.DistinctUntilChanged\n" +
+                        "import net.grandcentrix.thirtyinch.TiView\n" +
+                        "interface MyInterface : TiView {\n" +
+                        "   @DistinctUntilChanged\n" +
+                        "   fun test(id: String): Int\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(lintProject(CLASS_DISTINCTUNTILCHANGED, testInterface))
+                .containsOnlyOnce(TiIssue.AnnotationOnNonVoidMethod.id)
+    }
+
+    fun testJava_annotation_used_on_method_with_void_return_type_should_have_no_warning() {
+        val testInterface = java(
+                "package foo;\n" +
+                        "import net.grandcentrix.thirtyinch.distinctuntilchanged.DistinctUntilChanged;\n" +
+                        "import net.grandcentrix.thirtyinch.TiView;\n" +
+                        "public interface MyInterface extends TiView {\n" +
+                        "   @DistinctUntilChanged\n" +
+                        "   public void test(String id);\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(lintProject(CLASS_DISTINCTUNTILCHANGED, testInterface)).isEqualTo(NO_WARNINGS)
+    }
+
+    fun testKotlin_annotation_used_on_method_with_void_return_type_should_have_no_warning() {
+        val testInterface = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.distinctuntilchanged.DistinctUntilChanged\n" +
+                        "import net.grandcentrix.thirtyinch.TiView\n" +
+                        "interface MyInterface : TiView {\n" +
+                        "   @DistinctUntilChanged\n" +
+                        "   fun test(id: String)\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(lintProject(CLASS_DISTINCTUNTILCHANGED, testInterface)).isEqualTo(NO_WARNINGS)
+    }
+}

--- a/thirtyinch-lint/src/test/kotlin/net/grandcentrix/thirtyinch/lint/DistinctUntilChangedUsageDetectorTest.kt
+++ b/thirtyinch-lint/src/test/kotlin/net/grandcentrix/thirtyinch/lint/DistinctUntilChangedUsageDetectorTest.kt
@@ -30,13 +30,19 @@ private val CLASS_DISTINCTUNTILCHANGED = java(
                 "}"
 )
 
+private val CLASS_TIVIEW = java(
+        "package net.grandcentrix.thirtyinch;\n" +
+                "public interface TiView {}"
+)
+
 class DistinctUntilChangedUsageDetectorTest : LintDetectorTest() {
 
     override fun getDetector(): Detector = DistinctUntilChangedUsageDetector()
 
     override fun getIssues(): MutableList<Issue> = mutableListOf(
             DistinctUntilChangedUsageDetector.ISSUE_NO_PARAMETER,
-            DistinctUntilChangedUsageDetector.ISSUE_NON_VOID_RETURN_TYPE
+            DistinctUntilChangedUsageDetector.ISSUE_NON_VOID_RETURN_TYPE,
+            DistinctUntilChangedUsageDetector.ISSUE_NO_TIVIEW_CHILD
     )
 
     fun testJava_annotation_used_on_method_without_parameter_should_have_warning() {
@@ -50,7 +56,7 @@ class DistinctUntilChangedUsageDetectorTest : LintDetectorTest() {
                         "}"
         )
 
-        Assertions.assertThat(lintProject(CLASS_DISTINCTUNTILCHANGED, testInterface))
+        Assertions.assertThat(lintProject(CLASS_TIVIEW, CLASS_DISTINCTUNTILCHANGED, testInterface))
                 .containsOnlyOnce(TiIssue.DistinctUntilChangedWithoutParameter.id)
     }
 
@@ -65,7 +71,7 @@ class DistinctUntilChangedUsageDetectorTest : LintDetectorTest() {
                         "}"
         )
 
-        Assertions.assertThat(lintProject(CLASS_DISTINCTUNTILCHANGED, testInterface))
+        Assertions.assertThat(lintProject(CLASS_TIVIEW, CLASS_DISTINCTUNTILCHANGED, testInterface))
                 .containsOnlyOnce(TiIssue.DistinctUntilChangedWithoutParameter.id)
     }
 
@@ -80,7 +86,8 @@ class DistinctUntilChangedUsageDetectorTest : LintDetectorTest() {
                         "}"
         )
 
-        Assertions.assertThat(lintProject(CLASS_DISTINCTUNTILCHANGED, testInterface)).isEqualTo(NO_WARNINGS)
+        Assertions.assertThat(lintProject(CLASS_TIVIEW, CLASS_DISTINCTUNTILCHANGED, testInterface))
+                .isEqualTo(NO_WARNINGS)
     }
 
     fun testKotlin_annotation_used_on_method_with_parameter_should_have_no_warning() {
@@ -94,7 +101,8 @@ class DistinctUntilChangedUsageDetectorTest : LintDetectorTest() {
                         "}"
         )
 
-        Assertions.assertThat(lintProject(CLASS_DISTINCTUNTILCHANGED, testInterface)).isEqualTo(NO_WARNINGS)
+        Assertions.assertThat(lintProject(CLASS_TIVIEW, CLASS_DISTINCTUNTILCHANGED, testInterface))
+                .isEqualTo(NO_WARNINGS)
     }
 
     fun testJava_annotation_used_on_method_with_non_void_return_type_should_have_warning() {
@@ -108,7 +116,7 @@ class DistinctUntilChangedUsageDetectorTest : LintDetectorTest() {
                         "}"
         )
 
-        Assertions.assertThat(lintProject(CLASS_DISTINCTUNTILCHANGED, testInterface))
+        Assertions.assertThat(lintProject(CLASS_TIVIEW, CLASS_DISTINCTUNTILCHANGED, testInterface))
                 .containsOnlyOnce(TiIssue.AnnotationOnNonVoidMethod.id)
     }
 
@@ -123,7 +131,7 @@ class DistinctUntilChangedUsageDetectorTest : LintDetectorTest() {
                         "}"
         )
 
-        Assertions.assertThat(lintProject(CLASS_DISTINCTUNTILCHANGED, testInterface))
+        Assertions.assertThat(lintProject(CLASS_TIVIEW, CLASS_DISTINCTUNTILCHANGED, testInterface))
                 .containsOnlyOnce(TiIssue.AnnotationOnNonVoidMethod.id)
     }
 
@@ -138,7 +146,8 @@ class DistinctUntilChangedUsageDetectorTest : LintDetectorTest() {
                         "}"
         )
 
-        Assertions.assertThat(lintProject(CLASS_DISTINCTUNTILCHANGED, testInterface)).isEqualTo(NO_WARNINGS)
+        Assertions.assertThat(lintProject(CLASS_TIVIEW, CLASS_DISTINCTUNTILCHANGED, testInterface))
+                .isEqualTo(NO_WARNINGS)
     }
 
     fun testKotlin_annotation_used_on_method_with_void_return_type_should_have_no_warning() {
@@ -152,6 +161,127 @@ class DistinctUntilChangedUsageDetectorTest : LintDetectorTest() {
                         "}"
         )
 
-        Assertions.assertThat(lintProject(CLASS_DISTINCTUNTILCHANGED, testInterface)).isEqualTo(NO_WARNINGS)
+        Assertions.assertThat(lintProject(CLASS_TIVIEW, CLASS_DISTINCTUNTILCHANGED, testInterface))
+                .isEqualTo(NO_WARNINGS)
+    }
+
+    fun testJava_annotation_used_on_method_in_TiView_child_interface_should_have_no_warning() {
+        val testInterface = java(
+                "package foo;\n" +
+                        "import net.grandcentrix.thirtyinch.distinctuntilchanged.DistinctUntilChanged;\n" +
+                        "import net.grandcentrix.thirtyinch.TiView;\n" +
+                        "public interface MyInterface extends TiView {\n" +
+                        "   @DistinctUntilChanged\n" +
+                        "   public void test(String id);\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(lintProject(CLASS_TIVIEW, CLASS_DISTINCTUNTILCHANGED, testInterface))
+                .isEqualTo(NO_WARNINGS)
+    }
+
+    fun testKotlin_annotation_used_on_method_in_TiView_child_interface_should_have_no_warning() {
+        val testInterface = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.distinctuntilchanged.DistinctUntilChanged\n" +
+                        "import net.grandcentrix.thirtyinch.TiView\n" +
+                        "interface MyInterface : TiView {\n" +
+                        "   @DistinctUntilChanged\n" +
+                        "   fun test(id: String)\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(lintProject(CLASS_TIVIEW, CLASS_DISTINCTUNTILCHANGED, testInterface))
+                .isEqualTo(NO_WARNINGS)
+    }
+
+    fun testJava_annotation_used_on_method_in_TiView_child_class_should_have_warning() {
+        val testInterface = java(
+                "package foo;\n" +
+                        "import net.grandcentrix.thirtyinch.distinctuntilchanged.DistinctUntilChanged;\n" +
+                        "import net.grandcentrix.thirtyinch.TiView;\n" +
+                        "public class MyClass extends TiView {\n" +
+                        "   @DistinctUntilChanged\n" +
+                        "   public void test(String id);\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(lintProject(CLASS_TIVIEW, CLASS_DISTINCTUNTILCHANGED, testInterface))
+                .containsOnlyOnce(TiIssue.AnnotationOnNonTiView.id)
+    }
+
+    fun testKotlin_annotation_used_on_method_in_TiView_child_class_should_have_warning() {
+        val testInterface = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.distinctuntilchanged.DistinctUntilChanged\n" +
+                        "import net.grandcentrix.thirtyinch.TiView\n" +
+                        "class MyClass : TiView {\n" +
+                        "   @DistinctUntilChanged\n" +
+                        "   fun test(id: String)\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(lintProject(CLASS_TIVIEW, CLASS_DISTINCTUNTILCHANGED, testInterface))
+                .containsOnlyOnce(TiIssue.AnnotationOnNonTiView.id)
+    }
+
+    fun testJava_annotation_used_on_method_in_non_TiView_child_class_should_have_warning() {
+        val testInterface = java(
+                "package foo;\n" +
+                        "import net.grandcentrix.thirtyinch.distinctuntilchanged.DistinctUntilChanged;\n" +
+                        "import net.grandcentrix.thirtyinch.TiView;\n" +
+                        "public class MyClass {\n" +
+                        "   @DistinctUntilChanged\n" +
+                        "   public void test(String id);\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(lintProject(CLASS_DISTINCTUNTILCHANGED, testInterface))
+                .containsOnlyOnce(TiIssue.AnnotationOnNonTiView.id)
+    }
+
+    fun testKotlin_annotation_used_on_method_in_non_TiView_child_class_should_have_warning() {
+        val testInterface = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.distinctuntilchanged.DistinctUntilChanged\n" +
+                        "import net.grandcentrix.thirtyinch.TiView\n" +
+                        "class MyClass {\n" +
+                        "   @DistinctUntilChanged\n" +
+                        "   fun test(id: String)\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(lintProject(CLASS_DISTINCTUNTILCHANGED, testInterface))
+                .containsOnlyOnce(TiIssue.AnnotationOnNonTiView.id)
+    }
+
+    fun testJava_annotation_used_on_method_in_non_TiView_interface_class_should_have_warning() {
+        val testInterface = java(
+                "package foo;\n" +
+                        "import net.grandcentrix.thirtyinch.distinctuntilchanged.DistinctUntilChanged;\n" +
+                        "import net.grandcentrix.thirtyinch.TiView;\n" +
+                        "public interface MyView {\n" +
+                        "   @DistinctUntilChanged\n" +
+                        "   public void test(String id);\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(lintProject(CLASS_DISTINCTUNTILCHANGED, testInterface))
+                .containsOnlyOnce(TiIssue.AnnotationOnNonTiView.id)
+    }
+
+    fun testKotlin_annotation_used_on_method_in_non_TiView_interface_class_should_have_warning() {
+        val testInterface = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.distinctuntilchanged.DistinctUntilChanged\n" +
+                        "import net.grandcentrix.thirtyinch.TiView\n" +
+                        "interface MyClass {\n" +
+                        "   @DistinctUntilChanged\n" +
+                        "   fun test(id: String)\n" +
+                        "}"
+        )
+
+        Assertions.assertThat(lintProject(CLASS_DISTINCTUNTILCHANGED, testInterface))
+                .containsOnlyOnce(TiIssue.AnnotationOnNonTiView.id)
     }
 }

--- a/thirtyinch-lint/src/test/kotlin/net/grandcentrix/thirtyinch/lint/MissingViewInThirtyInchDetectorTest.kt
+++ b/thirtyinch-lint/src/test/kotlin/net/grandcentrix/thirtyinch/lint/MissingViewInThirtyInchDetectorTest.kt
@@ -457,6 +457,226 @@ class MissingViewInThirtyInchDetectorTest : LintDetectorTest() {
         ).isEqualTo(NO_WARNINGS)
     }
 
+    fun testJava_Activity_throughTransitiveBaseClass_withBasePresenter_withBaseView_noWarning() {
+        val baseView = java(
+                "package foo;\n" +
+                        "import net.grandcentrix.thirtyinch.*;\n" +
+                        "interface BaseView extends TiView {\n" +
+                        "}"
+        )
+
+        val basePresenter = java(
+                "package foo;\n" +
+                        "import net.grandcentrix.thirtyinch.*;\n" +
+                        "abstract class BasePresenter<V extends BaseView> extends TiPresenter<V> {\n" +
+                        "}"
+        )
+
+        val baseActivity = java(
+                "package foo;\n" +
+                        "import net.grandcentrix.thirtyinch.*;\n" +
+                        "abstract class BaseActivity<P extends BasePresenter<V>, V extends BaseView> extends TiActivity<P, V> {\n" +
+                        "}"
+        )
+
+        val activity = java(
+                "package foo;\n" +
+                        "class InformationActivity extends BaseActivity<MyPresenter, MyView> implements MyView {\n" +
+                        "}"
+        )
+
+        val view = java(
+                "package foo;\n" +
+                        "interface MyView extends BaseView {\n" +
+                        "}"
+        )
+
+        val customPresenter = java(
+                "package foo;\n" +
+                        "class MyPresenter extends BasePresenter<MyView> {\n" +
+                        "}"
+        )
+
+        assertThat(
+                lintProject(
+                        tiActivityStub,
+                        tiPresenterStub,
+                        tiViewStub,
+                        baseView,
+                        view,
+                        basePresenter,
+                        customPresenter,
+                        baseActivity,
+                        activity
+                )
+        ).isEqualTo(NO_WARNINGS)
+    }
+
+    fun testKotlin_Activity_throughTransitiveBaseClass_withBasePresenter_withBaseView_noWarning() {
+        val baseView = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.*\n" +
+                        "interface BaseView : TiView {\n" +
+                        "}"
+        )
+
+        val basePresenter = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.*\n" +
+                        "abstract class BasePresenter<V : BaseView> : TiPresenter<V>() {\n" +
+                        "}"
+        )
+
+        val baseActivity = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.*\n" +
+                        "abstract class BaseActivity<P : BasePresenter<V>, V : BaseView> : TiActivity<P, V>(), MyView {\n" +
+                        "}"
+        )
+
+        val activity = kotlin(
+                "package foo\n" +
+                        "class InformationActivity : BaseActivity<MyPresenter, MyView>() {\n" +
+                        "}"
+        )
+
+        val view = kotlin(
+                "package foo\n" +
+                        "interface MyView : BaseView {\n" +
+                        "}"
+        )
+
+        val customPresenter = kotlin(
+                "package foo\n" +
+                        "class MyPresenter : BasePresenter<MyView>() {\n" +
+                        "}"
+        )
+
+        assertThat(
+                lintProject(
+                        tiActivityStub,
+                        tiPresenterStub,
+                        tiViewStub,
+                        baseView,
+                        view,
+                        basePresenter,
+                        customPresenter,
+                        baseActivity,
+                        activity
+                )
+        ).isEqualTo(NO_WARNINGS)
+    }
+
+    fun testJava_Activity_throughTransitiveBaseClass_withBasePresenter_withBaseView_hasWarning() {
+        val baseView = java(
+                "package foo;\n" +
+                        "import net.grandcentrix.thirtyinch.*;\n" +
+                        "interface BaseView extends TiView {\n" +
+                        "}"
+        )
+
+        val basePresenter = java(
+                "package foo;\n" +
+                        "import net.grandcentrix.thirtyinch.*;\n" +
+                        "abstract class BasePresenter<V extends BaseView> extends TiPresenter<V> {\n" +
+                        "}"
+        )
+
+        val baseActivity = java(
+                "package foo;\n" +
+                        "import net.grandcentrix.thirtyinch.*;\n" +
+                        "abstract class BaseActivity<P extends BasePresenter<V>, V extends BaseView> extends TiActivity<P, V> {\n" +
+                        "}"
+        )
+
+        val activity = java(
+                "package foo;\n" +
+                        "class InformationActivity extends BaseActivity<MyPresenter, MyView> {\n" +
+                        "}"
+        )
+
+        val view = java(
+                "package foo;\n" +
+                        "interface MyView extends BaseView {\n" +
+                        "}"
+        )
+
+        val customPresenter = java(
+                "package foo;\n" +
+                        "class MyPresenter extends BasePresenter<MyView> {\n" +
+                        "}"
+        )
+
+        assertThat(
+                lintProject(
+                        tiActivityStub,
+                        tiPresenterStub,
+                        tiViewStub,
+                        baseView,
+                        view,
+                        basePresenter,
+                        customPresenter,
+                        baseActivity,
+                        activity
+                )
+        ).containsOnlyOnce(TiIssue.MissingView.id)
+    }
+
+    fun testKotlin_Activity_throughTransitiveBaseClass_withBasePresenter_withBaseView_hasWarning() {
+        val baseView = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.*\n" +
+                        "interface BaseView : TiView {\n" +
+                        "}"
+        )
+
+        val basePresenter = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.*\n" +
+                        "abstract class BasePresenter<V : BaseView> : TiPresenter<V>() {\n" +
+                        "}"
+        )
+
+        val baseActivity = kotlin(
+                "package foo\n" +
+                        "import net.grandcentrix.thirtyinch.*\n" +
+                        "abstract class BaseActivity<P : BasePresenter<V>, V : BaseView> : TiActivity<P, V>() {\n" +
+                        "}"
+        )
+
+        val activity = kotlin(
+                "package foo\n" +
+                        "class InformationActivity : BaseActivity<MyPresenter, MyView>() {\n" +
+                        "}"
+        )
+
+        val view = kotlin(
+                "package foo\n" +
+                        "interface MyView : BaseView {\n" +
+                        "}"
+        )
+
+        val customPresenter = kotlin(
+                "package foo\n" +
+                        "class MyPresenter : BasePresenter<MyView>() {\n" +
+                        "}"
+        )
+
+        assertThat(
+                lintProject(
+                        tiActivityStub,
+                        tiPresenterStub,
+                        tiViewStub,
+                        baseView,
+                        view,
+                        basePresenter,
+                        customPresenter,
+                        baseActivity,
+                        activity
+                )
+        ).containsOnlyOnce(TiIssue.MissingView.id)
+    }
+
     fun testKotlin_Activity_throughBaseClass_noWarning() {
         val baseActivity = kotlin(
                 "package foo;\n" +
@@ -488,7 +708,7 @@ class MissingViewInThirtyInchDetectorTest : LintDetectorTest() {
         val baseActivity = kotlin(
                 "package foo;\n" +
                         "import net.grandcentrix.thirtyinch.*;\n" +
-                        "public class BaseActivity : TiActivity<TiPresenter<MyView>, MyView>() {\n" +
+                        "public abstract class BaseActivity : TiActivity<TiPresenter<MyView>, MyView>() {\n" +
                         "}"
         )
 
@@ -825,7 +1045,7 @@ class MissingViewInThirtyInchDetectorTest : LintDetectorTest() {
         val baseFragment = kotlin(
                 "package foo\n" +
                         "import net.grandcentrix.thirtyinch.*\n" +
-                        "class BaseFragment : TiFragment<TiPresenter<MyView>, MyView>() {\n" +
+                        "abstract class BaseFragment : TiFragment<TiPresenter<MyView>, MyView>() {\n" +
                         "}"
         )
 

--- a/thirtyinch-lint/src/test/kotlin/net/grandcentrix/thirtyinch/lint/TiLintRegistryTest.kt
+++ b/thirtyinch-lint/src/test/kotlin/net/grandcentrix/thirtyinch/lint/TiLintRegistryTest.kt
@@ -15,7 +15,8 @@ class IssueRegistryTest {
                         MissingViewInThirtyInchDetector.ISSUE,
                         MissingViewInCompositeDetector.ISSUE,
                         DistinctUntilChangedUsageDetector.ISSUE_NO_PARAMETER,
-                        DistinctUntilChangedUsageDetector.ISSUE_NON_VOID_RETURN_TYPE
+                        DistinctUntilChangedUsageDetector.ISSUE_NON_VOID_RETURN_TYPE,
+                        DistinctUntilChangedUsageDetector.ISSUE_NO_TIVIEW_CHILD
                 )
     }
 }

--- a/thirtyinch-lint/src/test/kotlin/net/grandcentrix/thirtyinch/lint/TiLintRegistryTest.kt
+++ b/thirtyinch-lint/src/test/kotlin/net/grandcentrix/thirtyinch/lint/TiLintRegistryTest.kt
@@ -1,5 +1,6 @@
 package net.grandcentrix.thirtyinch.lint
 
+import net.grandcentrix.thirtyinch.lint.detector.DistinctUntilChangedUsageDetector
 import net.grandcentrix.thirtyinch.lint.detector.MissingViewInCompositeDetector
 import net.grandcentrix.thirtyinch.lint.detector.MissingViewInThirtyInchDetector
 import org.assertj.core.api.Assertions.*
@@ -12,7 +13,9 @@ class IssueRegistryTest {
         assertThat(TiLintRegistry().issues)
                 .containsExactly(
                         MissingViewInThirtyInchDetector.ISSUE,
-                        MissingViewInCompositeDetector.ISSUE
+                        MissingViewInCompositeDetector.ISSUE,
+                        DistinctUntilChangedUsageDetector.ISSUE_NO_PARAMETER,
+                        DistinctUntilChangedUsageDetector.ISSUE_NON_VOID_RETURN_TYPE
                 )
     }
 }


### PR DESCRIPTION
### Description
Annotations in Java can be restricted to some languages types like `Method` or `Class`. In ThirtyInch some of our annotations so are allowed but are useless and will not trigger the job for what they are intended.
This PR will bring Lint Checks will warn the dev about those cases right at the annotation usage.

### How to Test
Play with the following scenarios:
- Add a return type to `fun showText(text: String)` in the `SampleView` of the sample app
- Add `@DistinctUntilChanged` and a return type to `fun showText(text: String)` in the `SampleView` of the sample app
- Add `@DistinctUntilChanged` remove all parameters from `fun showText(text: String)` in the `SampleView` of the sample app
- Add `@DistinctUntilChanged` to any method in an arbitary class which is not an interface
- Add `@CallOnMainThread` to any method in an arbitary class which is not an interface
- Add `@DistinctUntilChanged` to any method in an arbitary class which does not extends `TiView`
- Add `@CallOnMainThread` to any method in an arbitary class which does not extends `TiView`
- Use TI v`0.10.0-SNAPSHOT` of this branch in another project where the cases above might be existing or produce them

Note: Always do a rebuild if you do a change in the Sample Project as it might has to be recompiled to pick the lint checks up.

### Merge Information
This PR builds on top of #187 so please do not merge this after #187 .
It will also ease the PR review a lot.

### Note
Testing Lint Checks in the Sample Project did not work reliably for me. This seems to be an Android Studio Issue as quite often an `Invalidate Caches and Restart` help.
A commandline lint run were reporting the errors reliably.