### PR TITLE
workaround for AndroidX Fragment 1.2.0 isInBackStack bug

### DIFF
--- a/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/util/BackstackReader.java
+++ b/thirtyinch/src/main/java/net/grandcentrix/thirtyinch/util/BackstackReader.java
@@ -4,6 +4,7 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.lang.reflect.Field;
 
 /**
  * Reads package private information about the {@link FragmentManager} backstack
@@ -23,9 +24,36 @@ public class BackstackReader {
      * Hacky workaround because Fragment#isInBackStack is inaccessible with AndroidX
      */
     public static boolean isInBackStack(final Fragment fragment) {
+        return isInBackStackAndroidX120(fragment);
+    }
+
+    /**
+     * Implementation which worked with AndroidX Fragment 1.1.0 and should be working again from 1.2.1:
+     * https://issuetracker.google.com/issues/148189412
+     */
+    private static boolean isInBackStackAndroidXOld(final Fragment fragment) {
         final StringWriter writer = new StringWriter();
         fragment.dump("", null, new PrintWriter(writer), null);
         final String dump = writer.toString();
         return !dump.contains("mBackStackNesting=0");
+    }
+
+    /**
+     * Temporary hack for the hack ;) because in AndroidX Fragment 1.2.0 the original `fragment.dump` hack stopped working:
+     * https://github.com/sockeqwe/mosby/issues/318#issuecomment-577660091
+     *
+     * Uses reflection, so should be removed once AndroidX Fragment 1.2.1 is released.
+     */
+    private static boolean isInBackStackAndroidX120(final Fragment fragment) {
+        try {
+            final Field backStackNestingField = Fragment.class.getDeclaredField("mBackStackNesting");
+            backStackNestingField.setAccessible(true);
+            final int backStackNesting = backStackNestingField.getInt(fragment);
+            return backStackNesting > 0;
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException(e);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
There is a bug in AndroidX Fragment 1.2.0 `dump()` which caused our `isInBackStack()` hack to crash the app on configuration change in fragment or when switching fragments:
https://github.com/sockeqwe/mosby/issues/318#issuecomment-577660091

The issue is supposed to be fixed in AndroidX Fragment 1.2.1 so we will have to remove the workaround and restore the old solution then:
https://issuetracker.google.com/issues/148189412

Please test fragment configuration change and switching between fragments. App should not crash.